### PR TITLE
Create Wrap-Promise

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,2 @@
+---
+  extends: braintree/client

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # wrap-promise
+
+Small module to help support APIs that return a promise or use a callback.
+
+### Example
+
+```js
+// my-method.js
+var wrapPromise = require('wrap-promise');
+
+function myMethod (arg) {
+  return new Promise(function (resolve, reject) {
+    doSomethingAsync(arg, function (err, response) {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(response);
+    });
+  });
+}
+
+module.exports = wrapPromise(myMethod);
+
+// my-app.js
+var myMethod = require('./my-method');
+
+myMethod('foo').then(function (response) {
+  // do something with response
+}).catch(function (err) {
+  // handle error
+});
+
+myMethod('foo', function (err, response) {
+  if (err) {
+    // handle error
+    return;
+  }
+
+  // do somethin with response
+});
+```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ myMethod('foo', function (err, response) {
     return;
   }
 
-  // do somethin with response
+  // do something with response
 });
 ```

--- a/lib/deferred.js
+++ b/lib/deferred.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function deferred(fn) {
+  return function () {
+    // IE9 doesn't support passing arguments to setTimeout so we have to emulate it.
+    var args = arguments;
+
+    setTimeout(function () {
+      fn.apply(null, args);
+    }, 1);
+  };
+}
+
+module.exports = deferred;

--- a/lib/once.js
+++ b/lib/once.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function once(fn) {
+  var called = false;
+
+  return function () {
+    if (!called) {
+      called = true;
+      fn.apply(null, arguments);
+    }
+  };
+}
+
+module.exports = once;

--- a/lib/promise-or-callback.js
+++ b/lib/promise-or-callback.js
@@ -1,0 +1,17 @@
+'use strict';
+
+function promiseOrCallback(promise, callback) { // eslint-disable-line consistent-return
+  if (callback) {
+    promise
+      .then(function (data) {
+        callback(null, data);
+      })
+      .catch(function (err) {
+        callback(err);
+      });
+  } else {
+    return promise;
+  }
+}
+
+module.exports = promiseOrCallback;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "wrap-promise",
+  "version": "1.0.0",
+  "description": "A small lib to return promises or use callbacks",
+  "main": "wrap-promise.js",
+  "files": ["wrap-promise", "lib/*"],
+  "dependencies": {},
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "eslint": "^2.7.0",
+    "eslint-config-braintree": "^1.0.2",
+    "mocha": "^3.2.0",
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "pretest": "npm run lint",
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/braintree/wrap-promise.git"
+  },
+  "keywords": [],
+  "author": "Braintree <code@getbraintree.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/braintree/wrap-promise/issues"
+  },
+  "homepage": "https://github.com/braintree/wrap-promise#readme"
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "keywords": [],
   "author": "Braintree <code@getbraintree.com>",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/braintree/wrap-promise/issues"
   },

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,11 @@
+---
+  env:
+    mocha: true
+
+  globals:
+    Promise: false
+    expect: false
+
+  rules:
+    no-invalid-this: 0
+    no-unused-expressions: 0

--- a/test/deferred.js
+++ b/test/deferred.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var deferred = require('../lib/deferred');
+
+describe('deferred', function () {
+  it('delays the call to the function', function (done) {
+    var fn = this.sandbox.spy(function () {
+      expect(arguments.length).to.equal(0);
+
+      done();
+    });
+    var def = deferred(fn);
+
+    def();
+
+    expect(fn).not.to.have.beenCalled;
+  });
+
+  it('can pass arguments to the delayed function', function (done) {
+    var fn = this.sandbox.spy(function (a, b) {
+      expect(arguments.length).to.equal(2);
+      expect(a).to.equal(1);
+      expect(b).to.equal(2);
+
+      done();
+    });
+    var def = deferred(fn);
+
+    def(1, 2);
+
+    expect(fn).not.to.have.beenCalled;
+  });
+});

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var sinon = require('sinon');
+var chai = require('chai');
+
+chai.use(require('sinon-chai'));
+
+global.expect = chai.expect;
+
+before(function () {
+  this.sandbox = sinon.sandbox.create();
+});
+
+afterEach(function () {
+  this.sandbox.restore();
+});

--- a/test/once.js
+++ b/test/once.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var once = require('../lib/once');
+
+describe('once', function () {
+  it('only calls function once', function () {
+    var funcOnlyCalledOnce;
+    var spy = this.sandbox.spy();
+
+    function func() {
+      spy();
+    }
+    funcOnlyCalledOnce = once(func);
+
+    expect(spy).to.not.be.called;
+
+    funcOnlyCalledOnce();
+
+    expect(spy).to.be.calledOnce;
+
+    funcOnlyCalledOnce();
+    funcOnlyCalledOnce();
+    funcOnlyCalledOnce();
+    funcOnlyCalledOnce();
+
+    expect(spy).to.be.calledOnce;
+  });
+});

--- a/test/promise-or-callback.js
+++ b/test/promise-or-callback.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var promiseOrCallback = require('../lib/promise-or-callback');
+
+function noop() {}
+
+function functionThatReturnsAResolvedPromise(data) {
+  return new Promise(function (resolve) {
+    resolve(data);
+  });
+}
+
+function functionThatReturnsARejectedPromise(err) {
+  return new Promise(function () {
+    throw err;
+  });
+}
+
+describe('promiseOrCallback', function () {
+  it('returns promise if no callback is provided', function () {
+    var promise = functionThatReturnsAResolvedPromise();
+    var isPromise = promiseOrCallback(promise);
+
+    expect(isPromise).to.be.an.instanceof(Promise);
+  });
+
+  it('does not return a promise if a callback is provided', function () {
+    var promise = functionThatReturnsAResolvedPromise();
+    var isPromise = promiseOrCallback(promise, noop);
+
+    expect(isPromise).to.not.be.an.instanceof(Promise);
+  });
+
+  it('calls callback with error caught from promise', function (done) {
+    var error = new Error('a problem');
+    var promise = functionThatReturnsARejectedPromise(error);
+
+    promiseOrCallback(promise, function (err) {
+      expect(err).to.equal(error);
+
+      done();
+    });
+  });
+
+  it('calls callback with data resolved from promise', function (done) {
+    var data = {foo: 'bar'};
+    var promise = functionThatReturnsAResolvedPromise(data);
+
+    promiseOrCallback(promise, function (err, resolvedData) {
+      expect(err).to.not.exist;
+      expect(resolvedData).to.equal(data);
+
+      done();
+    });
+  });
+});

--- a/test/wrap-promise.js
+++ b/test/wrap-promise.js
@@ -1,0 +1,113 @@
+'use strict';
+
+var wrapPromise = require('../wrap-promise');
+
+function noop() {}
+
+describe('wrapPromise', function () {
+  it('returns a function', function () {
+    var fn = wrapPromise(noop);
+
+    expect(fn).to.be.a('function');
+  });
+
+  context('functions without callbacks', function () {
+    it('invokes first parameter', function () {
+      var returnValue = {foo: 'bar'};
+      var fn;
+
+      function dummy() {
+        return returnValue;
+      }
+
+      fn = wrapPromise(dummy);
+
+      expect(fn()).to.equal(returnValue);
+    });
+
+    it('passes argument to first parameter', function (done) {
+      var fn;
+      var options = {
+        foo: 'bar'
+      };
+
+      function dummy(data) {
+        expect(data).to.equal(options);
+
+        done();
+      }
+
+      fn = wrapPromise(dummy);
+
+      fn(options);
+    });
+
+    it('passes along many arguments to first parameter', function (done) {
+      var fn;
+      var firstArg = {
+        foo: 'bar'
+      };
+      var secondArg = {
+        bar: 'baz'
+      };
+      var thirdArg = {
+        baz: 'buz'
+      };
+
+      function dummy(one, two, three) {
+        expect(one).to.equal(firstArg);
+        expect(two).to.equal(secondArg);
+        expect(three).to.equal(thirdArg);
+
+        done();
+      }
+
+      fn = wrapPromise(dummy);
+
+      fn(firstArg, secondArg, thirdArg);
+    });
+  });
+
+  context('last parameter is a callback', function () {
+    it('does not pass callback to the first param function', function () {
+      var promise = new Promise(noop);
+      var dummy = this.sandbox.stub().returns(promise);
+      var fn = wrapPromise(dummy);
+      var cb = noop;
+      var arg1 = {};
+      var arg2 = {};
+
+      fn(arg1, arg2, cb);
+
+      expect(dummy).to.be.calledWithExactly(arg1, arg2);
+    });
+
+    it('calls the callback with resolved promise', function (done) {
+      var data = {foo: 'bar'};
+      var promise = Promise.resolve(data);
+      var dummy = this.sandbox.stub().returns(promise);
+      var fn = wrapPromise(dummy);
+
+      fn({}, function (err, resolvedData) {
+        expect(err).to.not.exist;
+        expect(resolvedData).to.equal(data);
+
+        done();
+      });
+    });
+
+    it('calls the callback with rejected promise', function (done) {
+      var error = new Error('An Error');
+      var promise = Promise.reject(error);
+      var dummy = this.sandbox.stub().returns(promise);
+      var fn = wrapPromise(dummy);
+
+      fn({}, function (err, resolvedData) {
+        expect(resolvedData).to.not.exist;
+        expect(err).to.equal(error);
+
+        done();
+      });
+    });
+  });
+});

--- a/wrap-promise.js
+++ b/wrap-promise.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var deferred = require('./lib/deferred');
+var once = require('./lib/once');
+var promiseOrCallback = require('./lib/promise-or-callback');
+
+function wrapPromise(fn) {
+  return function () {
+    var callback;
+    var args = Array.prototype.slice.call(arguments);
+    var lastArg = args[args.length - 1];
+
+    if (typeof lastArg === 'function') {
+      callback = args.pop();
+      callback = once(deferred(callback));
+    }
+    return promiseOrCallback(fn.apply(this, args), callback); // eslint-disable-line no-invalid-this
+  };
+}
+
+module.exports = wrapPromise;


### PR DESCRIPTION
Adds wrap-promise as a separate module so braintree-web, braintree-web-drop-in and braintree_node can use the same logic. 