### PR TITLE
Add method to wrap the prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,25 @@ myMethod('foo', function (err, response) {
   // do something with response
 });
 ```
+
+### Wrap All Methods on the Prototype
+
+```js
+function MyObject() {}
+
+MyObject.prototype.myAsyncMethod = function () {
+  return new Promise (function (resolve, reject) {
+    //
+  });
+};
+
+MyObject.prototype.myOtherAsyncMethod = function () {
+  return new Promise (function (resolve, reject) {
+    //
+  });
+};
+
+module.exports = wrapPromise.wrapPrototype(MyObject);
+```
+
+Static methods, sync methods on the prototype (though if you pass a function as the last argument of your sync method, you will get an error), and non-function properties on the prototype are ignored.

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ module.exports = wrapPromise.wrapPrototype(MyObject, {
 });
 ```
 
-If you notate private methods with leading underscores, you can also ignore those by passing `ignorePrivateMethods: true`
+By default, `wrapPrototype` ignores methods that begin with an underscore. You can override this behavior by passing: `transformPrivateMethods: true`
 
 ```js
 module.exports = wrapPromise.wrapPrototype(MyObject, {
-  ignorePrivateMethods: true
+  transformPrivateMethods: true
 });
 ```

--- a/README.md
+++ b/README.md
@@ -71,3 +71,11 @@ module.exports = wrapPromise.wrapPrototype(MyObject, {
   ignoreMethods: ['myMethodOnThePrototypeIDoNotWantTransformed']
 });
 ```
+
+If you notate private methods with leading underscores, you can also ignore those by passing `ignorePrivateMethods: true`
+
+```js
+module.exports = wrapPromise.wrapPrototype(MyObject, {
+  ignorePrivateMethods: true
+});
+```

--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ module.exports = wrapPromise.wrapPrototype(MyObject);
 ```
 
 Static methods, sync methods on the prototype (though if you pass a function as the last argument of your sync method, you will get an error), and non-function properties on the prototype are ignored.
+
+If there are certain methods you want ignored, you can pass an `ignoreMethods` array.
+
+```js
+module.exports = wrapPromise.wrapPrototype(MyObject, {
+  ignoreMethods: ['myMethodOnThePrototypeIDoNotWantTransformed']
+});
+```

--- a/test/wrap-promise.js
+++ b/test/wrap-promise.js
@@ -179,6 +179,41 @@ describe('wrapPromise', function () {
       expect(obj.constructor.toString()).to.equal('function MyObject() {}');
     });
 
+    it.only('can pass in an options object to ignore methods', function () {
+      var obj;
+
+      function MyOtherObject() {}
+
+      MyOtherObject.prototype.transformMe = function () {
+        return Promise.resolve('yay');
+      };
+      MyOtherObject.prototype.ignoreMe = function (cb) {
+        cb();
+
+        return 'not a promise';
+      };
+      MyOtherObject.prototype.alsoIgnoreMe = function (cb) {
+        typeof cb;
+        cb();
+
+        return 'also not a promise';
+      };
+
+      wrapPromise.wrapPrototype(MyOtherObject, {
+        ignoreMethods: ['ignoreMe', 'alsoIgnoreMe']
+      });
+
+      obj = new MyOtherObject();
+
+      expect(obj.transformMe(noop)).to.be.undefined;
+      expect(function () {
+        obj.ignoreMe(noop);
+      }).to.not.throw();
+      expect(function () {
+        obj.alsoIgnoreMe(noop);
+      }).to.not.throw();
+    });
+
     describe('wraps each method on the prototype to use callbacks', function () {
       it('happy path', function (done) {
         var obj = new this.MyObject();

--- a/test/wrap-promise.js
+++ b/test/wrap-promise.js
@@ -179,7 +179,7 @@ describe('wrapPromise', function () {
       expect(obj.constructor.toString()).to.equal('function MyObject() {}');
     });
 
-    it.only('can pass in an options object to ignore methods', function () {
+    it('can pass in an options object to ignore methods', function () {
       var obj;
 
       function MyOtherObject() {}
@@ -211,6 +211,41 @@ describe('wrapPromise', function () {
       }).to.not.throw();
       expect(function () {
         obj.alsoIgnoreMe(noop);
+      }).to.not.throw();
+    });
+
+    it('can pass in an options object to ignore methods with leading underscores', function () {
+      var obj;
+
+      function MyOtherObject() {}
+
+      MyOtherObject.prototype.transformMe = function () {
+        return Promise.resolve('yay');
+      };
+      MyOtherObject.prototype._ignoreMe = function (cb) {
+        cb();
+
+        return 'not a promise';
+      };
+      MyOtherObject.prototype._alsoIgnoreMe = function (cb) {
+        typeof cb;
+        cb();
+
+        return 'also not a promise';
+      };
+
+      wrapPromise.wrapPrototype(MyOtherObject, {
+        ignorePrivateMethods: true
+      });
+
+      obj = new MyOtherObject();
+
+      expect(obj.transformMe(noop)).to.be.undefined;
+      expect(function () {
+        obj._ignoreMe(noop);
+      }).to.not.throw();
+      expect(function () {
+        obj._alsoIgnoreMe(noop);
       }).to.not.throw();
     });
 

--- a/wrap-promise.js
+++ b/wrap-promise.js
@@ -19,19 +19,21 @@ function wrapPromise(fn) {
 }
 
 wrapPromise.wrapPrototype = function (target, options) {
-  var methods, ignoreMethods, ignorePrivateMethods;
+  var methods, ignoreMethods, includePrivateMethods;
 
   options = options || {};
   ignoreMethods = options.ignoreMethods || [];
-  ignorePrivateMethods = Boolean(options.ignorePrivateMethods);
+  includePrivateMethods = options.transformPrivateMethods === true;
 
   methods = Object.getOwnPropertyNames(target.prototype).filter(function (method) {
-    var isNotPrivateMethod = true;
+    var isNotPrivateMethod;
     var isNonConstructorFunction = method !== 'constructor' &&
       typeof target.prototype[method] === 'function';
     var isNotAnIgnoredMethod = ignoreMethods.indexOf(method) === -1;
 
-    if (ignorePrivateMethods) {
+    if (includePrivateMethods) {
+      isNotPrivateMethod = true;
+    } else {
       isNotPrivateMethod = method.charAt(0) !== '_';
     }
 

--- a/wrap-promise.js
+++ b/wrap-promise.js
@@ -18,9 +18,16 @@ function wrapPromise(fn) {
   };
 }
 
-wrapPromise.wrapPrototype = function (target) {
-  var methods = Object.getOwnPropertyNames(target.prototype).filter(function (method) {
-    return method !== 'constructor' && typeof target.prototype[method] === 'function';
+wrapPromise.wrapPrototype = function (target, options) {
+  var methods, ignoreMethods;
+
+  options = options || {};
+  ignoreMethods = options.ignoreMethods || [];
+
+  methods = Object.getOwnPropertyNames(target.prototype).filter(function (method) {
+    return method !== 'constructor' &&
+      typeof target.prototype[method] === 'function' &&
+      ignoreMethods.indexOf(method) === -1;
   });
 
   methods.forEach(function (method) {

--- a/wrap-promise.js
+++ b/wrap-promise.js
@@ -18,4 +18,18 @@ function wrapPromise(fn) {
   };
 }
 
+wrapPromise.wrapPrototype = function (target) {
+  var methods = Object.getOwnPropertyNames(target.prototype).filter(function (method) {
+    return method !== 'constructor' && typeof target.prototype[method] === 'function';
+  });
+
+  methods.forEach(function (method) {
+    var original = target.prototype[method];
+
+    target.prototype[method] = wrapPromise(original);
+  });
+
+  return target;
+};
+
 module.exports = wrapPromise;

--- a/wrap-promise.js
+++ b/wrap-promise.js
@@ -19,15 +19,25 @@ function wrapPromise(fn) {
 }
 
 wrapPromise.wrapPrototype = function (target, options) {
-  var methods, ignoreMethods;
+  var methods, ignoreMethods, ignorePrivateMethods;
 
   options = options || {};
   ignoreMethods = options.ignoreMethods || [];
+  ignorePrivateMethods = Boolean(options.ignorePrivateMethods);
 
   methods = Object.getOwnPropertyNames(target.prototype).filter(function (method) {
-    return method !== 'constructor' &&
-      typeof target.prototype[method] === 'function' &&
-      ignoreMethods.indexOf(method) === -1;
+    var isNotPrivateMethod = true;
+    var isNonConstructorFunction = method !== 'constructor' &&
+      typeof target.prototype[method] === 'function';
+    var isNotAnIgnoredMethod = ignoreMethods.indexOf(method) === -1;
+
+    if (ignorePrivateMethods) {
+      isNotPrivateMethod = method.charAt(0) !== '_';
+    }
+
+    return isNonConstructorFunction &&
+      isNotPrivateMethod &&
+      isNotAnIgnoredMethod;
   });
 
   methods.forEach(function (method) {


### PR DESCRIPTION
This should ease some of the boilerplate and eslint-angriness around wrapping each method with the promise wrapper.

Now we can just do:

```js
module.exports = wrapPromise.wrapPrototype(Client);
```

@EvanHahn @ntomlin @braintree/team-dx 